### PR TITLE
optional this.websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const mediaStreamSaver = new TwilioMediaStreamSaveAudioFile({
 wss.on("connection", (ws) => {
   console.log("New connection initiated!");
 
-  mediaStreamSaver.setWebsocket(ws);
+  mediaStreamSaver.setWebsocket(ws); // optional
 
   ws.on("message", (message) => {
     const msg = JSON.parse(message);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ class TwilioMediaStreamSaveAudioFile {
     this.saveLocation = options.saveLocation || __dirname;
     this.saveFilename = options.saveFilename || Date.now();
     this.onSaved = options.onSaved || null;
-    this.websocket = null;
+    this.websocket = {};
   }
 
   get filename() {


### PR DESCRIPTION
Seeing as how `this.websocket` is only used as an object, defaults this parameter to a simple object. Enables using this library without having to supply a ws object.