### PR TITLE
remove unnecessary this.websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ const mediaStreamSaver = new TwilioMediaStreamSaveAudioFile({
 wss.on("connection", (ws) => {
   console.log("New connection initiated!");
 
-  mediaStreamSaver.setWebsocket(ws);
-
   ws.on("message", (message) => {
     const msg = JSON.parse(message);
     switch (msg.event) {
@@ -80,8 +78,6 @@ When you instantiate the library you can pass in the following options. They are
 - `onSaved` - **(Optional)** This is a optional callback function that you can provide if you want to be notified when the audio wav file has been saved.
 
 ## Notes
-
-- Once your websocket has connected call `mediaStreamSaver.setWebsocket(ws)`. The `ws` is what is returned from the the websocket `connection` event.
 
 - Inside the connected websocket `message` event make sure to call each of the corresponding methods for the incoming Twilio Media Stream message events: 
 

--- a/index.js
+++ b/index.js
@@ -85,6 +85,11 @@ class TwilioMediaStreamSaveAudioFile {
     );
   }
 
+  // @deprecated
+  setWebsocket(websocket) {
+    this.websocket = websocket
+  },
+
   twilioStreamMedia(mediaPayload) {
     // decode the base64-encoded data and write to stream
     this.wstream.write(Buffer.from(mediaPayload, "base64"));

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class TwilioMediaStreamSaveAudioFile {
   // @deprecated
   setWebsocket(websocket) {
     this.websocket = websocket
-  },
+  }
 
   twilioStreamMedia(mediaPayload) {
     // decode the base64-encoded data and write to stream

--- a/test.js
+++ b/test.js
@@ -15,8 +15,6 @@ describe('TwilioMediaStreamSaveAudioFile', () => {
       onSaved: () => console.log("File was saved!"),
     });
 
-    mediaStreamSaver.setWebsocket({});
-
     let twilioCallSid = null;
     let count = 0;
     for await (const line of rl) {


### PR DESCRIPTION
`this.websocket` was only being used to store the reference for `wstream`, so I removed it and stored `wstream` on `this` directly. This also means users of the library will not have to take the extra step of calling `setWebsocket` so it will make the library easier to use.