### PR TITLE
workflow targets the correct branch

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -2,9 +2,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The CI wasn't running before because the wrong branch was specified in the nodejs.yml workflow file. This should start running the CI on every pull request and push to the main branch.