### PR TITLE
Test and use filename and writeStreamPath getters

### DIFF
--- a/test.js
+++ b/test.js
@@ -42,7 +42,7 @@ describe('TwilioMediaStreamSaveAudioFile', () => {
       }
     }
 
-    const filename = `${__dirname}/my-twilio-media-stream-output.wav`;
+    const { filename } = mediaStreamSaver;
     const stats = await fs.promises.stat(filename);
     assert.equal(stats.size, 58138);
 

--- a/test.js
+++ b/test.js
@@ -42,10 +42,11 @@ describe('TwilioMediaStreamSaveAudioFile', () => {
       }
     }
 
-    const { filename } = mediaStreamSaver;
+    const { filename, writeStreamPath } = mediaStreamSaver;
+
     const stats = await fs.promises.stat(filename);
     assert.equal(stats.size, 58138);
 
-    await fs.promises.unlink(filename);
+    await fs.promises.unlink(writeStreamPath);
   });
 });


### PR DESCRIPTION
This will help test coverage and also removes the duplicate code to create the filename.